### PR TITLE
update free for life link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The issue with this method is that CloudFormation automatically creates an index
 
 ### Use a custom Domain
 
-For a more friendly URL, you can use your own subdomain instead of the Lambda Function URL. Don't forget that Lambda Function URL's are HTTPS only. You will need a redirect or if you prefer to use DNS (CNAME) you will need a valid HTTPS certificate for that domain. You can use one of the [Free For Life domains](https://free.wdh.gg/#/?id=domains) for this purpose.
+For a more friendly URL, you can use your own subdomain instead of the Lambda Function URL. Don't forget that Lambda Function URL's are HTTPS only. You will need a redirect or if you prefer to use DNS (CNAME) you will need a valid HTTPS certificate for that domain. You can use one of the [Free For Life domains](https://free.hrsn.dev/#/?id=domains) for this purpose.
 
 ## Files
 


### PR DESCRIPTION
Hey, me again. I am updating the Free For Life URL to this new domain as I may not renew wdh.gg in future, as well as .dev is a gTLD which will perform better in SEO, rather than a ccTLD.